### PR TITLE
US222 toe clip history check

### DIFF
--- a/src/components/ToeCodeInput.jsx
+++ b/src/components/ToeCodeInput.jsx
@@ -227,7 +227,11 @@ export default function ToeCodeInput({
      */
     const checkToeCodeValidity = useCallback(async () => {
         setIsValid(false);
-        if (toeCode.length < 2) {
+
+        if(toeCode.length == 0) {
+            setIsValid(true);
+            return; // we only want to close the modal if this is true here.. otherwise will we commit bad data to the DB.
+        } else if (toeCode.length < 2) {
             setIsValid(false);
             setOnCloseMsg('Toe Clip Code needs to be at least 2 characters long');
         } else if (toeCode.length % 2) {
@@ -383,6 +387,13 @@ export default function ToeCodeInput({
      * Updates the state with the found records and opens the recapture history modal.
      */
     const findPreviousLizardEntries = async () => {
+        if(speciesCode == null || speciesCode.length == 0) {
+            animationTimeout(
+                triggerErrorMsgAnimation,
+                'Please select a species code before continuing to history.'
+            );
+            return;
+        }
         setHistoryButtonText('Querying...');
         const collectionName =
             environment === 'live'

--- a/src/index.js
+++ b/src/index.js
@@ -15,14 +15,14 @@ import { LoginWrapper } from './pages/LoginWrapper';
 // Your web app's Firebase configuration
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const firebaseConfig = {
-    apiKey: "AIzaSyDf315Ml5vfmtGVYQJa2Kq7SxUAgg_2vqs",
-    authDomain: "field-day-backup.firebaseapp.com",
-    databaseURL: "https://field-day-backup-default-rtdb.firebaseio.com",
-    projectId: "field-day-backup",
-    storageBucket: "field-day-backup.appspot.com",
-    messagingSenderId: "846923163868",
-    appId: "1:846923163868:web:d79fdde0c3fe0057126c19",
-    measurementId: "G-ZNJTJKVD92"
+    apiKey: 'AIzaSyDf315Ml5vfmtGVYQJa2Kq7SxUAgg_2vqs',
+    authDomain: 'field-day-backup.firebaseapp.com',
+    databaseURL: 'https://field-day-backup-default-rtdb.firebaseio.com',
+    projectId: 'field-day-backup',
+    storageBucket: 'field-day-backup.appspot.com',
+    messagingSenderId: '846923163868',
+    appId: '1:846923163868:web:d79fdde0c3fe0057126c19',
+    measurementId: 'G-ZNJTJKVD92',
 };
 
 // Initialize Firebase

--- a/src/pages/AboutUs.jsx
+++ b/src/pages/AboutUs.jsx
@@ -1,6 +1,10 @@
 export default function AboutUs() {
     const teams = [
         {
+            year: '2024-2025',
+            names: ['Quinten Knowles', 'Ayesha Arif', 'Timothy Weaver', 'Chase Molstad', 'Evan Hagood']
+        },
+        {
             year: '2022-2023',
             names: ['Isaiah Lathem', 'Ian Skelskey', 'Jack Norman', 'Dennis Grassl', 'Zachary Jacobson']
         },


### PR DESCRIPTION
To reviewer: double check I did not overlook anything with the check in checkToeCodeValidity(). I added this to ensure that a user could still exit the toe clip code without entering one, but since isValid needs to be set to true to accomplish this, there's potentially some data corruption to the DB involved with that change. I looked it over, and it shouldn't ever do that, but a second pair of eyes is always nice.

Apart from that:
1. Adds an error message if recapture history is pressed without a species code selected
2. Lets a user close the modal without inputting a toe-clip code.